### PR TITLE
ENTESB-11638 Replace Enmasse with AMq-online

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,10 +1,12 @@
 = Camel AMQ QuickStart
 
-This quickstart demonstrates how to connect to EnMasse (MaaS) and use JMS messaging between two Camel routes.
+This quickstart demonstrates how to connect to AMQ Online and use JMS messaging between two Camel routes.
 
-In this example we will use two containers, one container to run as an EnMasse instance, and another as a client to the broker, where the Camel routes are running.
+IMPORTANT: The version of AMQ Online has to be at least 1.2
 
-This quickstart requires EnMasse to have been deployed and running first. To install EnMasse into OpenShift or Kubernetes follow https://enmasse.io/documentation/master/openshift/#installing-messaging[documentation].
+In this example we will use two containers, one container to run as an AMQ Online instance, and another as a client to the broker, where the Camel routes are running.
+
+This quickstart requires AMQ Online to have been deployed and running first. To install AMQ Online into OpenShift or Kubernetes follow https://access.redhat.com/documentation/en-us/red_hat_amq/7.4/html/installing_and_managing_amq_online_on_openshift_container_platform/installing-messaging[documentation].
 
 IMPORTANT: This quickstart can run in 1 mode: on Kubernetes / OpenShift Cluster
 
@@ -39,7 +41,7 @@ $ oc new-project MY_PROJECT_NAME
 $ cd my_openshift/karaf-camel-amq
 ----
 
-. Before running the quickstart, you need to configure EnMasse (to create user and queue - both as an admin). Run the following commands to apply configuration files:
+. Before running the quickstart, you need to configure AMQ Online (to create user and queue - both as an admin). Run the following commands to apply configuration files:
 
 +
 [source,bash,options="nowrap",subs="attributes+"]
@@ -84,7 +86,7 @@ $ oc login -u developer -p developer
 $ oc new-project MY_PROJECT_NAME
 ----
 
-. Import base images in your newly created project (MY_PROJECT_NAME) according to https://access.redhat.com/documentation/en-us/red_hat_fuse/7.4/html/fuse_on_openshift_guide/get-started-non-admin[documentation].
+. Import base images in your newly created project (MY_PROJECT_NAME) according to https://access.redhat.com/documentation/en-us/red_hat_fuse/7.6/html/fuse_on_openshift_guide/get-started-non-admin[documentation].
 
 . Change the directory to the folder that contains the extracted quickstart application (for example, `my_openshift/karaf-camel-amq`) :
 +
@@ -93,7 +95,7 @@ $ oc new-project MY_PROJECT_NAME
 $ cd my_openshift/karaf-camel-amq
 ----
 
-. Before running the quickstart, you need to configure EnMasse (to create user and queue - both as an admin). Run the following commands to apply configuration files:
+. Before running the quickstart, you need to configure AMQ Online (to create user and queue - both as an admin). Run the following commands to apply configuration files:
 
 +
 [source,bash,options="nowrap",subs="attributes+"]
@@ -106,7 +108,7 @@ $ oc apply -f src/main/resources/k8s
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ mvn clean -DskipTests fabric8:deploy -Popenshift -Dfabric8.generator.fromMode=istag -Dfabric8.generator.from=MY_PROJECT_NAME/fuse7-karaf-openshift:1.4
+$ mvn clean -DskipTests fabric8:deploy -Popenshift -Dfabric8.generator.fromMode=istag -Dfabric8.generator.from=MY_PROJECT_NAME/fuse7-karaf-openshift:1.6
 ----
 
 . In your browser, navigate to the `MY_PROJECT_NAME` project in the OpenShift console.


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-11638

Upgrading version of fuse to 7.6. Enmasse changed to AMQ Online.

Supersedes https://github.com/fabric8-quickstarts/karaf-camel-amq/pull/191