### PR TITLE
ENTESB-14969 Link Secrets Creation page to Quickstarts

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,19 +6,19 @@ IMPORTANT: The version of AMQ Online has to be at least 1.2
 
 In this example we will use two containers, one container to run as an AMQ Online instance, and another as a client to the broker, where the Camel routes are running.
 
-This quickstart requires AMQ Online to have been deployed and running first. To install AMQ Online into OpenShift or Kubernetes follow https://access.redhat.com/documentation/en-us/red_hat_amq/7.4/html/installing_and_managing_amq_online_on_openshift_container_platform/installing-messaging[documentation].
+This quickstart requires AMQ Online to have been deployed and running first. To install AMQ Online into OpenShift or Kubernetese follow https://access.redhat.com/documentation/en-us/red_hat_amq/7.4/html/installing_and_managing_amq_online_on_openshift_container_platform/installing-messaging[documentation]
 
-IMPORTANT: This quickstart can run in 1 mode: on Kubernetes / OpenShift Cluster
+IMPORTANT: This quickstart can run in 1 mode: on Kubernetese / OpenShift Cluster
 
-== Running the Quickstart on a single-node Kubernetes/OpenShift cluster
+== Running the Quickstart on a single-node Kubernetese/OpenShift cluster
 
 IMPORTANT: You need to run this example on Container Development Kit 3.3 or OpenShift 3.7.
 Both of these products have suitable Fuse images pre-installed.
 If you run it in an environment where those images are not preinstalled follow the steps described in <<single-node-without-preinstalled-images>>.
 
-A single-node Kubernetes/OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
+A single-node Kubernetese/OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
 
-If you have a single-node Kubernetes/OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can deploy your quickstart there.
+If you have a single-node Kubernetese/OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can deploy your quickstart there.
 
 . Log in to your OpenShift cluster:
 +
@@ -54,7 +54,7 @@ $ oc apply -f src/main/resources/k8s
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ mvn clean -DskipTests fabric8:deploy -Popenshift
+$ mvn clean -DskipTests oc:deploy -Popenshift
 ----
 
 . In your browser, navigate to the `MY_PROJECT_NAME` project in the OpenShift console.
@@ -65,12 +65,11 @@ Wait until you can see that the pod for the `karaf-camel-amq` has started up.
 . Switch to tab `Logs` and then see the messages sent by Camel.
 
 [#single-node-without-preinstalled-images]
-=== Running the Quickstart on a single-node Kubernetes/OpenShift cluster without preinstalled images
+=== Running the Quickstart on a single-node Kubernetese/OpenShift cluster without preinstalled images
 
-A single-node Kubernetes/OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
+A single-node Kubernetese/OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
 
-If you have a single-node Kubernetes/OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can deploy your quickstart there.
-
+If you have a single-node Kubernetese/OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can deploy your quickstart there.
 
 . Log in to your OpenShift cluster:
 +
@@ -86,7 +85,7 @@ $ oc login -u developer -p developer
 $ oc new-project MY_PROJECT_NAME
 ----
 
-. Import base images in your newly created project (MY_PROJECT_NAME) according to https://access.redhat.com/documentation/en-us/red_hat_fuse/7.7/html/fuse_on_openshift_guide/get-started-non-admin[documentation].
+. Import base images in your newly created project (MY_PROJECT_NAME) according to https://access.redhat.com/documentation/en-us/red_hat_fuse/7.3/html/fuse_on_openshift_guide/get-started-non-admin[documentation].
 
 . Change the directory to the folder that contains the extracted quickstart application (for example, `my_openshift/karaf-camel-amq`) :
 +
@@ -108,7 +107,7 @@ $ oc apply -f src/main/resources/k8s
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ mvn clean -DskipTests fabric8:deploy -Popenshift -Dfabric8.generator.fromMode=istag -Dfabric8.generator.from=MY_PROJECT_NAME/fuse7-karaf-openshift:1.7
+$ mvn clean -DskipTests oc:deploy -Popenshift -Djkube.generator.fromMode=istag -Djkube.generator.from=MY_PROJECT_NAME/fuse-karaf-openshift:1.9
 ----
 
 . In your browser, navigate to the `MY_PROJECT_NAME` project in the OpenShift console.
@@ -118,3 +117,6 @@ Wait until you can see that the pod for the `karaf-camel-amq` has started up.
 
 . Switch to tab `Logs` and then see the messages sent by Camel.
 
+---
+
+Generated by maven plugin - do NOT edit this file! (See https://github.com/jboss-fuse/documentation-template/blob/main/README.md[documentation])

--- a/src/main/doc/introduction.adoc
+++ b/src/main/doc/introduction.adoc
@@ -1,0 +1,9 @@
+= Camel AMQ QuickStart
+
+This quickstart demonstrates how to connect to AMQ Online and use JMS messaging between two Camel routes.
+
+IMPORTANT: The version of AMQ Online has to be at least 1.2
+
+In this example we will use two containers, one container to run as an AMQ Online instance, and another as a client to the broker, where the Camel routes are running.
+
+This quickstart requires AMQ Online to have been deployed and running first. To install AMQ Online into OpenShift or Kubernetese follow https://access.redhat.com/documentation/en-us/red_hat_amq/7.4/html/installing_and_managing_amq_online_on_openshift_container_platform/installing-messaging[documentation]

--- a/src/main/doc/oc-special-configuration.adoc
+++ b/src/main/doc/oc-special-configuration.adoc
@@ -1,0 +1,8 @@
+. Before running the quickstart, you need to configure AMQ Online (to create user and queue - both as an admin). Run the following commands to apply configuration files:
+
++
+[source,bash,options="nowrap",subs="attributes+"]
+----
+$ oc login -u system:admin
+$ oc apply -f src/main/resources/k8s
+----


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-14969

Change refactors quickstart to use a template for documentation + template adds missing instruction to add secret.